### PR TITLE
[Part 1] 3- Adding Cache In Front Microservice

### DIFF
--- a/api-clusters/src/main/resources/application-docker.yml
+++ b/api-clusters/src/main/resources/application-docker.yml
@@ -37,7 +37,7 @@ redis:
 
 connector:
    catalog:
-      host: api-catalog:6070
+      host: varnish:80
       responseTimeout: 2000
       connectionTimeout: 2000
       readTimeout: 2000

--- a/api-provider-alpha/src/main/resources/application-docker.yml
+++ b/api-provider-alpha/src/main/resources/application-docker.yml
@@ -33,7 +33,7 @@ spring:
     
 connector:
    catalog:
-      host: api-catalog:6070
+      host: varnish:80
       responseTimeout: 1000
       connectionTimeout: 1000
       readTimeout: 1000

--- a/api-provider-beta/src/main/resources/application-docker.yml
+++ b/api-provider-beta/src/main/resources/application-docker.yml
@@ -33,7 +33,7 @@ spring:
         
 connector:
    catalog:
-      host: api-catalog:6070
+      host: varnish:80
       responseTimeout: 1000
       connectionTimeout: 1000
       readTimeout: 1000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,4 +65,12 @@ services:
     container_name: api-provider-beta
     ports:
      - 9070:9070
-    restart: always      
+    restart: always
+
+  varnish:
+    build: ./varnish
+    container_name: varnish
+    ports:
+      - 80:80
+    depends_on:
+      - api-catalog

--- a/varnish/Dockerfile
+++ b/varnish/Dockerfile
@@ -1,0 +1,6 @@
+FROM varnish:6.5
+
+COPY default.vcl /etc/varnish/
+COPY run.sh /run.sh
+
+RUN chmod +x /run.sh

--- a/varnish/default.vcl
+++ b/varnish/default.vcl
@@ -1,0 +1,30 @@
+vcl 4.0;
+
+backend default {
+  .host = "api-catalog";
+  .port = "6070";
+}
+
+sub vcl_deliver {
+  # Display hit/miss info
+  if (obj.hits > 0) {
+    set resp.http.V-Cache = "HIT";
+  }
+  else {
+    set resp.http.V-Cache = "MISS";
+  }
+  set resp.http.Access-Control-Allow-Origin = "*";
+  set resp.http.Allow = "GET";
+  set resp.http.Access-Control-Allow-Methods = "GET";
+}
+
+sub vcl_backend_response {
+  if (beresp.status == 200) {
+    unset beresp.http.Cache-Control;
+    set beresp.http.Cache-Control = "public; max-age=200";
+    set beresp.ttl = 200s;
+  }
+  set beresp.http.Served-By = beresp.backend.name;
+  set beresp.http.V-Cache-TTL = beresp.ttl;
+  set beresp.http.V-Cache-Grace = beresp.grace;
+}

--- a/varnish/run.sh
+++ b/varnish/run.sh
@@ -1,0 +1,1 @@
+varnishd -f /etc/varnish/default.vcl


### PR DESCRIPTION
### Objective

Your third task as a developer is to add a cache mechanism in front of the Catalog API, and to change the configuration of the rest of the microservices (api-clusters, api-provider-alpha, api-provider-beta) to reduce the number of requests.

### Deliverable

The deliverable for this milestone is the code of the microservices with the modifications in the configuration of the port of the Catalog API and the docker-compose file with the modification to add Varnish.