### PR TITLE
[Part 4] 3- Adding a rate limit

### DIFF
--- a/api-clusters/src/main/java/com/twa/flights/api/clusters/controller/ClustersController.java
+++ b/api-clusters/src/main/java/com/twa/flights/api/clusters/controller/ClustersController.java
@@ -1,5 +1,6 @@
 package com.twa.flights.api.clusters.controller;
 
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +32,7 @@ public class ClustersController implements ClustersResources {
     }
 
     @Override
+    @RateLimiter(name = "priceItineraries")
     public ResponseEntity<ClusterSearchDTO> availability(ClustersAvailabilityRequestDTO request) {
         LOGGER.debug("Obtain all the itineraries with price");
         requestValidator.validate(request);

--- a/api-clusters/src/main/java/com/twa/flights/api/clusters/controller/ClustersController.java
+++ b/api-clusters/src/main/java/com/twa/flights/api/clusters/controller/ClustersController.java
@@ -1,5 +1,10 @@
 package com.twa.flights.api.clusters.controller;
 
+import com.twa.flights.api.clusters.controller.documentation.ClustersResources;
+import com.twa.flights.api.clusters.dto.ClusterSearchDTO;
+import com.twa.flights.api.clusters.dto.request.ClustersAvailabilityRequestDTO;
+import com.twa.flights.api.clusters.service.ClustersService;
+import com.twa.flights.api.clusters.validator.AvailabilityRequestValidator;
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,36 +14,35 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.twa.flights.api.clusters.controller.documentation.ClustersResources;
-import com.twa.flights.api.clusters.dto.ClusterSearchDTO;
-import com.twa.flights.api.clusters.dto.request.ClustersAvailabilityRequestDTO;
-import com.twa.flights.api.clusters.service.ClustersService;
-import com.twa.flights.api.clusters.validator.AvailabilityRequestValidator;
-
 @RestController
 @RequestMapping("/")
 public class ClustersController implements ClustersResources {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ClustersController.class);
+   private static final Logger LOGGER = LoggerFactory.getLogger(ClustersController.class);
 
-    private final ClustersService clustersService;
+   private final ClustersService clustersService;
 
-    private final AvailabilityRequestValidator requestValidator;
+   private final AvailabilityRequestValidator requestValidator;
 
-    @Autowired
-    public ClustersController(ClustersService clustersService, AvailabilityRequestValidator requestValidator) {
-        this.clustersService = clustersService;
-        this.requestValidator = requestValidator;
-    }
+   @Autowired
+   public ClustersController(ClustersService clustersService, AvailabilityRequestValidator requestValidator) {
+      this.clustersService = clustersService;
+      this.requestValidator = requestValidator;
+   }
 
-    @Override
-    @RateLimiter(name = "priceItineraries")
-    public ResponseEntity<ClusterSearchDTO> availability(ClustersAvailabilityRequestDTO request) {
-        LOGGER.debug("Obtain all the itineraries with price");
-        requestValidator.validate(request);
+   @Override
+   @RateLimiter(name = "priceItineraries", fallbackMethod = "fallBack")
+   public ResponseEntity<ClusterSearchDTO> availability(ClustersAvailabilityRequestDTO request) {
+      LOGGER.debug("Obtain all the itineraries with price");
+      requestValidator.validate(request);
 
-        ClusterSearchDTO response = clustersService.availability(request);
-        return new ResponseEntity<>(response, HttpStatus.OK);
-    }
+      ClusterSearchDTO response = clustersService.availability(request);
+      return new ResponseEntity<>(response, HttpStatus.OK);
+   }
+
+   @SuppressWarnings("unsued")
+   private ResponseEntity<ClusterSearchDTO> fallback(ClustersAvailabilityRequestDTO request) {
+      return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).build();
+   }
 
 }

--- a/api-clusters/src/main/java/com/twa/flights/api/clusters/controller/ClustersController.java
+++ b/api-clusters/src/main/java/com/twa/flights/api/clusters/controller/ClustersController.java
@@ -5,6 +5,7 @@ import com.twa.flights.api.clusters.dto.ClusterSearchDTO;
 import com.twa.flights.api.clusters.dto.request.ClustersAvailabilityRequestDTO;
 import com.twa.flights.api.clusters.service.ClustersService;
 import com.twa.flights.api.clusters.validator.AvailabilityRequestValidator;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,31 +19,31 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/")
 public class ClustersController implements ClustersResources {
 
-   private static final Logger LOGGER = LoggerFactory.getLogger(ClustersController.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClustersController.class);
 
-   private final ClustersService clustersService;
+    private final ClustersService clustersService;
 
-   private final AvailabilityRequestValidator requestValidator;
+    private final AvailabilityRequestValidator requestValidator;
 
-   @Autowired
-   public ClustersController(ClustersService clustersService, AvailabilityRequestValidator requestValidator) {
-      this.clustersService = clustersService;
-      this.requestValidator = requestValidator;
-   }
+    @Autowired
+    public ClustersController(ClustersService clustersService, AvailabilityRequestValidator requestValidator) {
+        this.clustersService = clustersService;
+        this.requestValidator = requestValidator;
+    }
 
-   @Override
-   @RateLimiter(name = "priceItineraries", fallbackMethod = "fallBack")
-   public ResponseEntity<ClusterSearchDTO> availability(ClustersAvailabilityRequestDTO request) {
-      LOGGER.debug("Obtain all the itineraries with price");
-      requestValidator.validate(request);
+    @Override
+    @RateLimiter(name = "priceItineraries", fallbackMethod = "fallback")
+    public ResponseEntity<ClusterSearchDTO> availability(ClustersAvailabilityRequestDTO request) {
+        LOGGER.debug("Obtain all the itineraries with price");
+        requestValidator.validate(request);
 
-      ClusterSearchDTO response = clustersService.availability(request);
-      return new ResponseEntity<>(response, HttpStatus.OK);
-   }
+        ClusterSearchDTO response = clustersService.availability(request);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
 
-   @SuppressWarnings("unsued")
-   private ResponseEntity<ClusterSearchDTO> fallback(ClustersAvailabilityRequestDTO request) {
-      return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).build();
-   }
+    @SuppressWarnings("unsued")
+    private ResponseEntity<Void> fallback(ClustersAvailabilityRequestDTO request, RequestNotPermitted requestNotPermitted) {
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).build();
+    }
 
 }

--- a/api-clusters/src/main/resources/application-docker.yml
+++ b/api-clusters/src/main/resources/application-docker.yml
@@ -76,3 +76,10 @@ resilience4j.circuitbreaker:
         - java.lang.RuntimeException
         - io.netty.handler.timeout.ReadTimeoutException
         - com.twa.flights.api.clusters.exception.TWAException
+
+resilience4j.ratelimiter:
+  instances:
+    priceItineraries:
+      timeoutDuration: 1000ms
+      limitRefreshPeriod: 10s
+      limitForPeriod: 2

--- a/api-clusters/src/main/resources/application-docker.yml
+++ b/api-clusters/src/main/resources/application-docker.yml
@@ -80,6 +80,7 @@ resilience4j.circuitbreaker:
 resilience4j.ratelimiter:
   instances:
     priceItineraries:
+      registerHealthIndicator: true
       timeoutDuration: 1000ms
       limitRefreshPeriod: 10s
       limitForPeriod: 2

--- a/api-clusters/src/main/resources/application.yml
+++ b/api-clusters/src/main/resources/application.yml
@@ -76,3 +76,10 @@ resilience4j.circuitbreaker:
         - java.lang.RuntimeException
         - io.netty.handler.timeout.ReadTimeoutException
         - com.twa.flights.api.clusters.exception.TWAException
+
+resilience4j.ratelimiter:
+  instances:
+    priceItineraries:
+      timeoutDuration: 1000ms
+      limitRefreshPeriod: 10s
+      limitForPeriod: 2

--- a/api-clusters/src/main/resources/application.yml
+++ b/api-clusters/src/main/resources/application.yml
@@ -80,6 +80,7 @@ resilience4j.circuitbreaker:
 resilience4j.ratelimiter:
   instances:
     priceItineraries:
+      registerHealthIndicator: true
       timeoutDuration: 1000ms
       limitRefreshPeriod: 10s
       limitForPeriod: 2

--- a/api-itineraries-search/src/main/java/com/twa/flights/api/itineraries/search/facade/ProviderAlphaFacade.java
+++ b/api-itineraries-search/src/main/java/com/twa/flights/api/itineraries/search/facade/ProviderAlphaFacade.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,29 +19,29 @@ import com.twa.flights.common.dto.request.AvailabilityRequestDTO;
 @Component
 public class ProviderAlphaFacade implements ProviderFacade {
 
-   static final Logger LOGGER = LoggerFactory.getLogger(ProviderAlphaFacade.class);
+    static final Logger LOGGER = LoggerFactory.getLogger(ProviderAlphaFacade.class);
 
-   ProviderAlphaConnector itinerariesSearchConnector;
+    ProviderAlphaConnector itinerariesSearchConnector;
 
-   @Autowired
-   public ProviderAlphaFacade(ProviderAlphaConnector itinerariesSearchConnector) {
-      this.itinerariesSearchConnector = itinerariesSearchConnector;
-   }
+    @Autowired
+    public ProviderAlphaFacade(ProviderAlphaConnector itinerariesSearchConnector) {
+        this.itinerariesSearchConnector = itinerariesSearchConnector;
+    }
 
-   @CircuitBreaker(name = "providerAlpha")
-   @RateLimiter(name = "providerAlpha", fallbackMethod = "fallback")
-   public List<ItineraryDTO> availability(AvailabilityRequestDTO request) {
-      LOGGER.debug("Obtain the information about the flights");
-      return itinerariesSearchConnector.availability(request);
-   }
+    @CircuitBreaker(name = "providerAlpha")
+    @RateLimiter(name = "providerAlpha", fallbackMethod = "fallback")
+    public List<ItineraryDTO> availability(AvailabilityRequestDTO request) {
+        LOGGER.debug("Obtain the information about the flights");
+        return itinerariesSearchConnector.availability(request);
+    }
 
-   @Override
-   public Provider getProvider() {
-      return Provider.ALPHA;
-   }
+    @Override
+    public Provider getProvider() {
+        return Provider.ALPHA;
+    }
 
-   @SuppressWarnings("unsued")
-   private List<ItineraryDTO> fallback(AvailabilityRequestDTO request) {
-      return Collections.emptyList();
-   }
+    @SuppressWarnings("unsued")
+    private List<ItineraryDTO> fallback(AvailabilityRequestDTO request, RequestNotPermitted requestNotPermitted) {
+        return Collections.emptyList();
+    }
 }

--- a/api-itineraries-search/src/main/java/com/twa/flights/api/itineraries/search/facade/ProviderAlphaFacade.java
+++ b/api-itineraries-search/src/main/java/com/twa/flights/api/itineraries/search/facade/ProviderAlphaFacade.java
@@ -1,5 +1,6 @@
 package com.twa.flights.api.itineraries.search.facade;
 
+import java.util.Collections;
 import java.util.List;
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
@@ -17,25 +18,29 @@ import com.twa.flights.common.dto.request.AvailabilityRequestDTO;
 @Component
 public class ProviderAlphaFacade implements ProviderFacade {
 
-    static final Logger LOGGER = LoggerFactory.getLogger(ProviderAlphaFacade.class);
+   static final Logger LOGGER = LoggerFactory.getLogger(ProviderAlphaFacade.class);
 
-    ProviderAlphaConnector itinerariesSearchConnector;
+   ProviderAlphaConnector itinerariesSearchConnector;
 
-    @Autowired
-    public ProviderAlphaFacade(ProviderAlphaConnector itinerariesSearchConnector) {
-        this.itinerariesSearchConnector = itinerariesSearchConnector;
-    }
+   @Autowired
+   public ProviderAlphaFacade(ProviderAlphaConnector itinerariesSearchConnector) {
+      this.itinerariesSearchConnector = itinerariesSearchConnector;
+   }
 
-    @CircuitBreaker(name = "providerAlpha")
-    @RateLimiter(name = "providerAlpha")
-    public List<ItineraryDTO> availability(AvailabilityRequestDTO request) {
-        LOGGER.debug("Obtain the information about the flights");
-        return itinerariesSearchConnector.availability(request);
-    }
+   @CircuitBreaker(name = "providerAlpha")
+   @RateLimiter(name = "providerAlpha", fallbackMethod = "fallback")
+   public List<ItineraryDTO> availability(AvailabilityRequestDTO request) {
+      LOGGER.debug("Obtain the information about the flights");
+      return itinerariesSearchConnector.availability(request);
+   }
 
-    @Override
-    public Provider getProvider() {
-        return Provider.ALPHA;
-    }
+   @Override
+   public Provider getProvider() {
+      return Provider.ALPHA;
+   }
 
+   @SuppressWarnings("unsued")
+   private List<ItineraryDTO> fallback(AvailabilityRequestDTO request) {
+      return Collections.emptyList();
+   }
 }

--- a/api-itineraries-search/src/main/java/com/twa/flights/api/itineraries/search/facade/ProviderAlphaFacade.java
+++ b/api-itineraries-search/src/main/java/com/twa/flights/api/itineraries/search/facade/ProviderAlphaFacade.java
@@ -3,6 +3,7 @@ package com.twa.flights.api.itineraries.search.facade;
 import java.util.List;
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +27,7 @@ public class ProviderAlphaFacade implements ProviderFacade {
     }
 
     @CircuitBreaker(name = "providerAlpha")
+    @RateLimiter(name = "providerAlpha")
     public List<ItineraryDTO> availability(AvailabilityRequestDTO request) {
         LOGGER.debug("Obtain the information about the flights");
         return itinerariesSearchConnector.availability(request);

--- a/api-itineraries-search/src/main/resources/application-docker.yml
+++ b/api-itineraries-search/src/main/resources/application-docker.yml
@@ -68,3 +68,10 @@ resilience4j.circuitbreaker:
         - java.lang.RuntimeException
         - io.netty.handler.timeout.ReadTimeoutException
         - com.twa.flights.api.itineraries.search.exception.TWAException
+
+resilience4j.ratelimiter:
+  instances:
+    providerAlpha:
+      timeoutDuration: 1000ms
+      limitRefreshPeriod: 15s
+      limitForPeriod: 2

--- a/api-itineraries-search/src/main/resources/application-docker.yml
+++ b/api-itineraries-search/src/main/resources/application-docker.yml
@@ -72,6 +72,7 @@ resilience4j.circuitbreaker:
 resilience4j.ratelimiter:
   instances:
     providerAlpha:
+      registerHealthIndicator: true
       timeoutDuration: 1000ms
       limitRefreshPeriod: 15s
       limitForPeriod: 2

--- a/api-itineraries-search/src/main/resources/application.yml
+++ b/api-itineraries-search/src/main/resources/application.yml
@@ -68,3 +68,10 @@ resilience4j.circuitbreaker:
         - java.lang.RuntimeException
         - io.netty.handler.timeout.ReadTimeoutException
         - com.twa.flights.api.itineraries.search.exception.TWAException
+
+resilience4j.ratelimiter:
+  instances:
+    providerAlpha:
+      timeoutDuration: 1000ms
+      limitRefreshPeriod: 15s
+      limitForPeriod: 2

--- a/api-itineraries-search/src/main/resources/application.yml
+++ b/api-itineraries-search/src/main/resources/application.yml
@@ -72,6 +72,7 @@ resilience4j.circuitbreaker:
 resilience4j.ratelimiter:
   instances:
     providerAlpha:
+      registerHealthIndicator: true
       timeoutDuration: 1000ms
       limitRefreshPeriod: 15s
       limitForPeriod: 2


### PR DESCRIPTION
### Objective

For your third day on the job, you will add a mechanism to limit the number of requests to api-clusters and api-provider-alpha, which you know will not support a large number of requests in a period.

### Deliverable

The deliverable for this milestone is the code of all the microservices with the rate limit modification in api-clusters limiting it to 2 requests in 10 seconds and the rate limit modification in `api-itineraries-search’ limiting it to 2 requests in 15 seconds.